### PR TITLE
Use 1 instead of true, to avoid errors with new AVRs.

### DIFF
--- a/RDA5807M.cpp
+++ b/RDA5807M.cpp
@@ -42,7 +42,7 @@ word RDA5807M::getRegister(byte reg) {
     Wire.beginTransmission(RDA5807M_I2C_ADDR_RANDOM);
     Wire.write(reg);
     Wire.endTransmission(false);
-    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, 1);
     //Don't let gcc play games on us, enforce order of execution.
     result = (word)Wire.read() << 8;
     result |= Wire.read();
@@ -62,7 +62,7 @@ void RDA5807M::setRegisterBulk(byte count, const word regs[]) {
 };
 
 void RDA5807M::getRegisterBulk(byte count, word regs[]) {
-    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, 1);
 
     for(byte i=0; i < count; i++) {
         //Don't let gcc play games on us, enforce order of execution.
@@ -86,7 +86,7 @@ void RDA5807M::getRegisterBulk(TRDA5807MRegisterFileRead *regs) {
     uint8_t * const ptr = (uint8_t *)regs;
 
     Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA,
-                     sizeof(TRDA5807MRegisterFileRead), true);
+                     sizeof(TRDA5807MRegisterFileRead), 1);
 
     for(byte i=0; i < sizeof(TRDA5807MRegisterFileRead); i++)
         ptr[i] = Wire.read();

--- a/RDA5807M.cpp
+++ b/RDA5807M.cpp
@@ -42,7 +42,7 @@ word RDA5807M::getRegister(byte reg) {
     Wire.beginTransmission(RDA5807M_I2C_ADDR_RANDOM);
     Wire.write(reg);
     Wire.endTransmission(false);
-    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, (size_t *)true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, (size_t)true);
     //Don't let gcc play games on us, enforce order of execution.
     result = (word)Wire.read() << 8;
     result |= Wire.read();
@@ -62,7 +62,7 @@ void RDA5807M::setRegisterBulk(byte count, const word regs[]) {
 };
 
 void RDA5807M::getRegisterBulk(byte count, word regs[]) {
-    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, (size_t *)true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, (size_t)true);
 
     for(byte i=0; i < count; i++) {
         //Don't let gcc play games on us, enforce order of execution.

--- a/RDA5807M.cpp
+++ b/RDA5807M.cpp
@@ -42,7 +42,7 @@ word RDA5807M::getRegister(byte reg) {
     Wire.beginTransmission(RDA5807M_I2C_ADDR_RANDOM);
     Wire.write(reg);
     Wire.endTransmission(false);
-    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, 1);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, true);
     //Don't let gcc play games on us, enforce order of execution.
     result = (word)Wire.read() << 8;
     result |= Wire.read();
@@ -62,7 +62,7 @@ void RDA5807M::setRegisterBulk(byte count, const word regs[]) {
 };
 
 void RDA5807M::getRegisterBulk(byte count, word regs[]) {
-    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, 1);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, true);
 
     for(byte i=0; i < count; i++) {
         //Don't let gcc play games on us, enforce order of execution.
@@ -86,7 +86,7 @@ void RDA5807M::getRegisterBulk(TRDA5807MRegisterFileRead *regs) {
     uint8_t * const ptr = (uint8_t *)regs;
 
     Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA,
-                     sizeof(TRDA5807MRegisterFileRead), 1);
+                     sizeof(TRDA5807MRegisterFileRead), true);
 
     for(byte i=0; i < sizeof(TRDA5807MRegisterFileRead); i++)
         ptr[i] = Wire.read();

--- a/RDA5807M.cpp
+++ b/RDA5807M.cpp
@@ -42,7 +42,7 @@ word RDA5807M::getRegister(byte reg) {
     Wire.beginTransmission(RDA5807M_I2C_ADDR_RANDOM);
     Wire.write(reg);
     Wire.endTransmission(false);
-    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, (size_t)true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, (size_t)2, true);
     //Don't let gcc play games on us, enforce order of execution.
     result = (word)Wire.read() << 8;
     result |= Wire.read();
@@ -62,7 +62,7 @@ void RDA5807M::setRegisterBulk(byte count, const word regs[]) {
 };
 
 void RDA5807M::getRegisterBulk(byte count, word regs[]) {
-    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, (size_t)true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, (size_t)(count * 2), true);
 
     for(byte i=0; i < count; i++) {
         //Don't let gcc play games on us, enforce order of execution.

--- a/RDA5807M.cpp
+++ b/RDA5807M.cpp
@@ -42,7 +42,7 @@ word RDA5807M::getRegister(byte reg) {
     Wire.beginTransmission(RDA5807M_I2C_ADDR_RANDOM);
     Wire.write(reg);
     Wire.endTransmission(false);
-    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_RANDOM, 2, (size_t *)true);
     //Don't let gcc play games on us, enforce order of execution.
     result = (word)Wire.read() << 8;
     result |= Wire.read();
@@ -62,7 +62,7 @@ void RDA5807M::setRegisterBulk(byte count, const word regs[]) {
 };
 
 void RDA5807M::getRegisterBulk(byte count, word regs[]) {
-    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, true);
+    Wire.requestFrom(RDA5807M_I2C_ADDR_SEQRDA, count * 2, (size_t *)true);
 
     for(byte i=0; i < count; i++) {
         //Don't let gcc play games on us, enforce order of execution.


### PR DESCRIPTION
Using any of the new 0 or 1-series chips (at least with [megaTinyCore](https://github.com/SpenceKonde/megaTinyCore)) with Wire.requestFrom using "true" instead of "1" for the bool will throw a huge fit and not compile, complaining that it's too ambiguous.
I don't entirely understand the issue, but [here](https://forum.arduino.cc/index.php?topic=623194.msg4314394#msg4314394) is a forum post referencing it.

In any case, I don't see how this change could hurt anything, and it allows the library to work with new chips.